### PR TITLE
refactor: renamed the package to resilicache

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-# ZenCache
+# ResiliCache
 
 A Cache package for Go which works with Redis, RedisCluster, ValKey, KeyDB, DragonflyDB and Kvrocks.

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/driftdev/zencache
+module github.com/driftdev/resilicache
 
 go 1.22.6
 

--- a/lua_script.go
+++ b/lua_script.go
@@ -1,4 +1,4 @@
-package zencache
+package resilicache
 
 import "github.com/redis/go-redis/v9"
 

--- a/resilicache.go
+++ b/resilicache.go
@@ -1,4 +1,4 @@
-package zencache
+package resilicache
 
 import (
 	"context"

--- a/util.go
+++ b/util.go
@@ -1,4 +1,4 @@
-package zencache
+package resilicache
 
 import (
 	"context"


### PR DESCRIPTION
# Changes

- refactor: renamed the package to resilicache

# Reason

- Package name was changed to resilicache a combination of resilient + cache to emphasize the resilient caching capability of the package  